### PR TITLE
fix: add a space after the comma in the text below

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -34,17 +34,17 @@ copyright = "Openpitrix Technology © 2018"
     [languages.en.index.first]
         title = "Application Management"
         subtitle = "Platform on Multi-Cloud Environment"
-        desc = "OpenPitrix is an Open-source, enterprise  system for  package ,deploy and orchestration applications into multiple cloud environments such as QingCloud, AWS, Kubernetes etc."
+        desc = "OpenPitrix is an Open-source, enterprise  system for  package , deploy and orchestration applications into multiple cloud environments such as QingCloud, AWS, Kubernetes etc."
         link = "COMING SOON…"
     [languages.en.index.second]
         title = "Why OpenPitrix?"
         desc_begin = "Since software used in business, diversity software was developed. For example, categorize by architecture："
-        desc_end = "This is Cloud era, so all above application must run on cloud computing, Just like QingCloud,AWS, Or VMware, Kubernetes based envrionment. Which framework or platform can do this? So OpenPitrix make sence, born for resovle this problem."
+        desc_end = "This is Cloud era, so all above application must run on cloud computing, Just like QingCloud, AWS, Or VMware, Kubernetes based envrionment. Which framework or platform can do this? So OpenPitrix make sence, born for resovle this problem."
         [[languages.en.index.second.architecture]]
             name = "Java EE traditional enterprise application."
             weight = 1
         [[languages.en.index.second.architecture]]
-            name = "LAMP ( linux,apache,mysql/postgresql,php/python/perl ) Open Source Software stack."
+            name = "LAMP ( linux, apache, mysql/postgresql, php/python/perl ) Open Source Software stack."
             weight = 2
         [[languages.en.index.second.architecture]]
             name = "Virtalization image."
@@ -63,10 +63,10 @@ copyright = "Openpitrix Technology © 2018"
         desc = "Significantly reduce learning costs and operational complexity through declarative template specifications, reducing development cycles from months to days or even hours, dramatically reducing cloud application development, deployment and operational complexity."
     [languages.en.index.fourth]
         title = "Support multiple cloud platforms"
-        desc_begin = "Adopted plug-in style development framework, abstraction the current mainstream cloud platform interface , uniform them for the user is completely transparent, reducing complexity for application developer."
-        desc_end = "public cloud platform supported include: AWS, GCE, Azure, QingCloud,etc.\r\nprivate cloud platform supported : Kubernetes, OpenStack, QingCloud,etc. "
+        desc_begin = "Adopted plug-in style development framework, abstraction the current mainstream cloud platform interface, uniform them for the user is completely transparent, reducing complexity for application developer."
+        desc_end = "public cloud platform supported include: AWS, GCE, Azure, QingCloud, etc.\r\nprivate cloud platform supported : Kubernetes, OpenStack, QingCloud, etc. "
     [languages.en.index.fifth]
-        title = "Unify all kind of application,monolitic,microservice,distributed,etc."
+        title = "Unify all kind of application, monolitic, microservice, distributed, etc."
         desc = "The technology is evolving, application is same, but old sytle not disappear. all kinds of application coexist in cloud computing era. OpenPitrix adopted distributed configurtion management, abstract meta configuration infomation, compatible with all(almost) application."
     [languages.en.index.sixth]
         title = "Adopted microservice for openpitrix itself"
@@ -110,12 +110,12 @@ copyright = "Openpitrix Technology © 2018"
     [languages.zh.index.second]
         title = "Why OpenPitrix?"
         desc_begin = "Since software used in business, diversity software was developed. For example, categorize by architecture："
-        desc_end = "This is Cloud era, so all above application must run on cloud computing, Just like QingCloud,AWS, Or VMware, Kubernetes based envrionment. Which framework or platform can do this? So OpenPitrix make sence, born for resovle this problem."
+        desc_end = "This is Cloud era, so all above application must run on cloud computing, Just like QingCloud, AWS, Or VMware, Kubernetes based envrionment. Which framework or platform can do this? So OpenPitrix make sence, born for resovle this problem."
         [[languages.zh.index.second.architecture]]
             name = "Java EE traditional enterprise application."
             weight = 1
         [[languages.zh.index.second.architecture]]
-            name = "LAMP ( linux,apache,mysql/postgresql,php/python/perl ) Open Source Software stack."
+            name = "LAMP ( linux, apache, mysql/postgresql, php/python/perl ) Open Source Software stack."
             weight = 2
         [[languages.zh.index.second.architecture]]
             name = "Virtalization image."
@@ -134,10 +134,10 @@ copyright = "Openpitrix Technology © 2018"
         desc = "Significantly reduce learning costs and operational complexity through declarative template specifications, reducing development cycles from months to days or even hours, dramatically reducing cloud application development, deployment and operational complexity."
     [languages.zh.index.fourth]
         title = "Support multiple cloud platforms"
-        desc_begin = "Adopted plug-in style development framework, abstraction the current mainstream cloud platform interface , uniform them for the user is completely transparent, reducing complexity for application developer."
-        desc_end = "public cloud platform supported include: AWS, GCE, Azure, QingCloud,etc.\r\nprivate cloud platform supported : Kubernetes, OpenStack, QingCloud,etc. "
+        desc_begin = "Adopted plug-in style development framework, abstraction the current mainstream cloud platform interface, uniform them for the user is completely transparent, reducing complexity for application developer."
+        desc_end = "public cloud platform supported include: AWS, GCE, Azure, QingCloud, etc.\r\nprivate cloud platform supported : Kubernetes, OpenStack, QingCloud, etc."
     [languages.zh.index.fifth]
-        title = "Unify all kind of application,monolitic,microservice,distributed,etc."
+        title = "Unify all kind of application, monolitic, microservice, distributed, etc."
         desc = "The technology is evolving, application is same, but old sytle not disappear. all kinds of application coexist in cloud computing era. OpenPitrix adopted distributed configurtion management, abstract meta configuration infomation, compatible with all(almost) application."
     [languages.zh.index.sixth]
         title = "Adopted microservice for openpitrix itself"
@@ -155,4 +155,3 @@ copyright = "Openpitrix Technology © 2018"
     note = "/note/:year/:month/:day/:slug/"
 [params]
     description = "A website built through Hugo and blogdown."
-


### PR DESCRIPTION
see #39 
Don't use hyphens, use whole word wrap.
This is because there is no space after the comma, which leads to mistakenly thinking of a long word.
The space after the comma has been added.